### PR TITLE
Setup docs and workflow scaffolding

### DIFF
--- a/.github/scripts/codex_todo_runner.py
+++ b/.github/scripts/codex_todo_runner.py
@@ -1,0 +1,12 @@
+"""Stub helper for Codex-driven TODO automation."""
+
+import os
+
+
+def main():
+    # Future implementation: parse CODEX TODO blocks and open PR via GitHub CLI
+    print("Codex TODO runner placeholder")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,20 @@
+name: Codex Auto-PR
+on:
+  push:
+    paths:
+      - '**/*.py'
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.todo'
+jobs:
+  codex-pr:
+    if: contains(github.event.head_commit.message, 'TODO')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run Codex on TODO blocks
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python .github/scripts/codex_todo_runner.py

--- a/DOCS/capsule_graph.md
+++ b/DOCS/capsule_graph.md
@@ -1,0 +1,11 @@
+## Capsule spec (v0)
+
+| field       | dtype            | bytes | note                              |
+|-------------|------------------|-------|-----------------------------------|
+| id          | uint64           | 8     | global unique                     |
+| vec         | int8[dim]        | d     | bipolar or ternary hypervector    |
+| last_used   | uint32           | 4     | unix-epoch seconds                |
+| edge_ids    | uint64[k]        | 8k    | neighbour capsule ids (sparse)    |
+| edge_wts    | int16[k]         | 2k    | signed 16-bit weights             |
+
+Default `dim = 2048`, `k \u2264 5` hot edges.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# HERG
-Hypervector Emergent Reasoning Graph
+# HERG — Hypervector Emergent Reasoning Graph
+
+Experimental engine that fuses
+* deterministic hypervector encodings,
+* persistent “capsule” nodes,
+* a sparse capsule-to-capsule graph, and
+* a lightweight GNN message pass
+
+…to enable continual, branching reasoning on commodity GPUs.
+
+See `DOCS/capsule_graph.md` for the design spec.

--- a/papers/AMT-overview.txt
+++ b/papers/AMT-overview.txt
@@ -1,0 +1,1 @@
+This is a placeholder for the AMT overview paper.

--- a/papers/current paper.txt
+++ b/papers/current paper.txt
@@ -1,0 +1,1 @@
+This is a placeholder for the current paper text.

--- a/src/encoder.py
+++ b/src/encoder.py
@@ -1,0 +1,21 @@
+"""Prototype hypervector encoder."""
+
+import numpy as np
+
+ENC_DIM = 2048
+
+
+def seed_to_hyper(seed: int, dim: int = ENC_DIM) -> np.ndarray:
+    """Generate a deterministic int8 hypervector from a seed."""
+    rng = np.random.RandomState(seed)
+    vec = rng.randint(-128, 128, size=dim, dtype=np.int8)
+    return vec
+
+# ❑ CODEX: scaffold Capsule dataclass in graph_caps/capsule.py
+#     fields = (id: int, vec: torch.IntTensor, last_used: int, edge_ids: list[int], edge_wts: list[int])
+#     include .to(device) helper
+
+# ❑ CODEX: implement sparse EdgeCOO tensor in graph_caps/edge_table.py
+#     api: add_edge(src, dst, w), neighbors(id) -> (ids, wts)
+
+# ❑ CODEX: write CapsuleStore with spawn/read/update/prune using sticky_pool policy


### PR DESCRIPTION
## Summary
- add placeholder papers and minimal encoder prototype
- document the capsule graph spec
- wire up Codex Auto-PR workflow
- seed TODO blocks for Codex to expand later

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ebacdf1c8325b5f994e565980296