### PR TITLE
Implement run_chat REPL

### DIFF
--- a/run_chat.py
+++ b/run_chat.py
@@ -3,7 +3,7 @@ import sys
 import time
 import signal
 
-from herg.graph_caps import CapsuleStore
+from herg.graph_caps.store import CapsuleStore
 from herg.snapshot import save_snapshot, load_snapshot
 from herg import backend as B
 
@@ -14,37 +14,26 @@ def main() -> None:
     except Exception:
         store = CapsuleStore()
 
-    stop = False
-
-    def handle_sigint(signum, frame):
-        nonlocal stop
-        stop = True
-
-    signal.signal(signal.SIGINT, handle_sigint)
-
-    token_count = 0
-    cos_sum = 0.0
-    prev_vec = None
-
-    try:
-        for line in sys.stdin:
-            if stop:
-                break
-            tokens = line.strip().split()
-            for tok in tokens:
-                cap = store.spawn(tok.encode(), ts=int(time.time()))
-                if prev_vec is not None:
-                    cos_sum += B.cosine(cap.vec, prev_vec)
-                prev_vec = cap.vec
-                token_count += 1
-                if token_count % 50 == 0:
-                    avg_cos = cos_sum / max(1, token_count - 1)
-                    print(f"{len(store.caps)} capsules, avg_cos={avg_cos:.2f}")
-    except KeyboardInterrupt:
-        pass
-    finally:
+    def handler(sig, frame):
         store.prune()
         save_snapshot(store, "brains/auto.pkl")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, handler)
+
+    token_count = 0
+    for line in sys.stdin:
+        tokens = line.strip().split()
+        for t in tokens:
+            store.spawn(t.encode(), ts=int(time.time()))
+            token_count += 1
+            if token_count % 50 == 0:
+                vecs = [cap.vec for cap in store.caps.values()]
+                avg_cos = (
+                    sum(B.cosine(a, b) for a, b in zip(vecs, vecs[1:]))
+                    / max(len(vecs) - 1, 1)
+                )
+                print(f"{len(store.caps)} capsules, avg_cos={avg_cos:.2f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement REPL for capsule store
- compute average cosine similarity every 50 tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68548bbaef248325a01bc5b75ab316e1