### PR TITLE
Implement snapshot CLI and tests

### DIFF
--- a/herg/cli.py
+++ b/herg/cli.py
@@ -1,0 +1,30 @@
+# ◇ CODEX_IMPLEMENT: snapshot CLI
+import argparse, sys
+from herg.snapshot import save_snapshot, load_snapshot
+from herg.graph_caps.store import CapsuleStore
+
+
+def main():
+    parser = argparse.ArgumentParser("herg snapshot")
+    subs = parser.add_subparsers(dest="cmd")
+    save_p = subs.add_parser("save")
+    save_p.add_argument("path")
+    load_p = subs.add_parser("load")
+    load_p.add_argument("path")
+    args = parser.parse_args()
+    if args.cmd == "save":
+        try:
+            store = load_snapshot(args.path)
+        except Exception:
+            store = CapsuleStore()
+        save_snapshot(store, args.path)
+        print(f"Saved {len(store.caps)} capsules")
+    elif args.cmd == "load":
+        store = load_snapshot(args.path)
+        print(f"Loaded {len(store.caps)} capsules")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/herg/cupy_encoder.py
+++ b/herg/cupy_encoder.py
@@ -48,7 +48,10 @@ def seed_to_cupy(seed: bytes, dim: int = 6000, simulate_error: bool = False):
         sign = 0.7071 if bit else -0.7071
         signs.append(sign)
     arr = xp.asarray(signs, dtype=xp.float32)
-    noise = xp.random.normal(0.0, 0.01, size=dim, dtype=xp.float32)
+    if xp is np:
+        noise = xp.random.normal(0.0, 0.01, size=dim).astype(xp.float32)
+    else:
+        noise = xp.random.normal(0.0, 0.01, size=dim, dtype=xp.float32)
     arr = arr + noise
     arr = sinc_kernel.modulate(arr, digest)
     return B.tensor(arr, dtype=np.float32)

--- a/herg/snapshot.py
+++ b/herg/snapshot.py
@@ -1,7 +1,7 @@
 # ◇ CODEX_IMPLEMENT: implement snapshot CLI helpers
 import pickle
 from pathlib import Path
-from herg.graph_caps import CapsuleStore
+from herg.graph_caps.store import CapsuleStore
 
 
 def save_snapshot(store: CapsuleStore, path: str) -> None:

--- a/herg/viz.py
+++ b/herg/viz.py
@@ -1,5 +1,5 @@
 # ◇ CODEX_IMPLEMENT: implement herg/viz.py visualization helper
-from herg.graph_caps import CapsuleStore
+from herg.graph_caps.store import CapsuleStore
 
 
 def viz_dot(store: CapsuleStore, last_n: int = 500) -> str:

--- a/integrations/llm_hook.py
+++ b/integrations/llm_hook.py
@@ -1,18 +1,24 @@
 # ◇ CODEX_IMPLEMENT: stub LLM hook to concat capsule context
 from typing import List
-from herg.graph_caps import CapsuleStore
+from herg.graph_caps.store import CapsuleStore
 
 
 def hook_forward(hidden_states, token_ids: List[int], store: CapsuleStore):
     import torch
 
+    hidden_dim = hidden_states.shape[-1]
     cap_vecs = []
     for tid in token_ids:
         cap = store.read(tid)
         if cap is None:
-            cap_vecs.append(torch.zeros(store.dim))
+            vec = torch.zeros(hidden_dim)
         else:
-            cap_vecs.append(torch.tensor(cap.vec, dtype=torch.float32))
-    cap_batch = torch.stack(cap_vecs, dim=1)
+            vec = torch.tensor(cap.vec, dtype=torch.float32)
+            if vec.numel() > hidden_dim:
+                vec = vec[:hidden_dim]
+            elif vec.numel() < hidden_dim:
+                vec = torch.nn.functional.pad(vec, (0, hidden_dim - vec.numel()))
+        cap_vecs.append(vec)
+    cap_batch = torch.stack(cap_vecs, dim=0)
     return torch.cat([hidden_states, cap_batch], dim=-1)
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,0 +1,12 @@
+# ◇ CODEX_IMPLEMENT: test hook_forward shape
+import torch
+from herg.graph_caps.store import CapsuleStore
+from integrations.llm_hook import hook_forward
+
+
+def test_hook_forward():
+    store = CapsuleStore()
+    hidden = torch.zeros(1, 768)
+    seed = b"x"
+    out = hook_forward(hidden, [seed], store)
+    assert out.shape[1] == hidden.shape[1] * 2

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,17 @@
+# ◇ CODEX_IMPLEMENT: test promote/demote device toggling
+import numpy as np
+from herg.graph_caps import Capsule
+from herg.graph_caps.store import CapsuleStore
+from herg import backend as B
+import pytest
+
+
+def test_promote_demote(tmp_path):
+    store = CapsuleStore()
+    cap = store.spawn(b"x", ts=0)
+    cap.demote()
+    assert B.device_of(cap.vec) == "cpu"
+    cap.promote(dim=2048)
+    if B.device_of(cap.vec) == "cpu":
+        pytest.skip("No GPU available")
+    assert B.device_of(cap.vec) != "cpu"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,14 @@
+# ◇ CODEX_IMPLEMENT: test save/load round-trip
+import pickle, pytest
+from herg.graph_caps.store import CapsuleStore
+from herg.snapshot import save_snapshot, load_snapshot
+
+
+def test_save_and_load(tmp_path):
+    store = CapsuleStore()
+    store.spawn(b"x", ts=0)
+    path = str(tmp_path / "brain.pkl")
+    save_snapshot(store, path)
+    new = load_snapshot(path)
+    assert isinstance(new, CapsuleStore)
+    assert len(new.caps) == 1

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,12 @@
+# ◇ CODEX_IMPLEMENT: test viz_dot output
+from herg.graph_caps.store import CapsuleStore
+from herg.viz import viz_dot
+
+
+def test_viz_dot(tmp_path):
+    store = CapsuleStore()
+    a = store.spawn(b"a", ts=0)
+    b = store.spawn(b"b", ts=0)
+    store.edges.add_edge(a.id, b.id, 1)
+    dot = viz_dot(store, last_n=2)
+    assert str(a.id) in dot and str(b.id) in dot and "->" in dot


### PR DESCRIPTION
## Summary
- add simple CLI for snapshot save/load
- fix imports in snapshot, viz, and hook modules
- adjust cupy encoder for NumPy
- make LLM hook pad/trim capsule vectors
- add tests for snapshot round trip, viz output, hook, and promote/demote

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548f906f888325a5b602995c3ab741