### PR TITLE
Implement viz, hook, and capsule promotion features

### DIFF
--- a/herg/graph_caps/__init__.py
+++ b/herg/graph_caps/__init__.py
@@ -24,15 +24,15 @@ class Capsule:
         self.vec = B.tensor(B.as_numpy(self.vec), dtype=np.int8, device=device)
 
     def promote(self, dim: int = 6000) -> None:
-        # only promote if currently on CPU
         if B.device_of(self.vec) != "cpu":
             return
         from herg.cupy_encoder import seed_to_cupy
-        self.vec = seed_to_cupy(self.id.to_bytes(32, 'big'), dim=dim)
+        self.vec = seed_to_cupy(self.id.to_bytes(32, "big"), dim=dim)
 
     def demote(self) -> None:
         import numpy as np
-        self.vec = B.tensor(self.vec, dtype=np.int8, device="cpu")
+        from herg import backend as B
+        self.vec = B.tensor(B.as_numpy(self.vec), dtype=np.int8, device="cpu")
 
 
 class EdgeCOO:

--- a/herg/viz.py
+++ b/herg/viz.py
@@ -4,16 +4,25 @@ from herg.graph_caps.store import CapsuleStore
 
 def viz_dot(store: CapsuleStore, last_n: int = 500) -> str:
     nodes = list(store.caps.keys())[-last_n:]
-    edges = [
-        (src, dst, wt)
-        for src in nodes
-        for dst, wt in zip(*store.edges.neighbors(src))
-    ]
-    dot = ["digraph G {"]
-    for n in nodes:
-        dot.append(f'  "{n}";')
-    for s, d, _ in edges:
-        dot.append(f'  "{s}" -> "{d}";')
-    dot.append("}")
-    return "\n".join(dot)
+    dot_lines = ["digraph G {"]
+    for node_id in nodes:
+        dot_lines.append(f'  "{node_id}";')
+        dsts, _ = store.edges.neighbors(node_id)
+        for dst in dsts:
+            dot_lines.append(f'  "{node_id}" -> "{dst}";')
+    dot_lines.append("}")
+    return "\n".join(dot_lines)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser("herg viz")
+    parser.add_argument("--last", type=int, default=500)
+    args = parser.parse_args()
+
+    from herg.graph_caps.store import CapsuleStore
+
+    store = CapsuleStore()
+    print(viz_dot(store, last_n=args.last))
 

--- a/integrations/llm_hook.py
+++ b/integrations/llm_hook.py
@@ -3,22 +3,25 @@ from typing import List
 from herg.graph_caps.store import CapsuleStore
 
 
-def hook_forward(hidden_states, token_ids: List[int], store: CapsuleStore):
+def hook_forward(
+    hidden_states,
+    token_seeds: List[bytes],
+    store: CapsuleStore,
+):
     import torch
 
     hidden_dim = hidden_states.shape[-1]
     cap_vecs = []
-    for tid in token_ids:
-        cap = store.read(tid)
-        if cap is None:
-            vec = torch.zeros(hidden_dim)
-        else:
-            vec = torch.tensor(cap.vec, dtype=torch.float32)
-            if vec.numel() > hidden_dim:
-                vec = vec[:hidden_dim]
-            elif vec.numel() < hidden_dim:
-                vec = torch.nn.functional.pad(vec, (0, hidden_dim - vec.numel()))
+    for seed in token_seeds:
+        cap = store.spawn(seed, ts=None)
+        vec = torch.tensor(cap.vec, dtype=hidden_states.dtype, device=hidden_states.device)
+        if vec.numel() > hidden_dim:
+            vec = vec[:hidden_dim]
+        elif vec.numel() < hidden_dim:
+            vec = torch.nn.functional.pad(vec, (0, hidden_dim - vec.numel()))
         cap_vecs.append(vec)
+
     cap_batch = torch.stack(cap_vecs, dim=0)
+
     return torch.cat([hidden_states, cap_batch], dim=-1)
 


### PR DESCRIPTION
## Summary
- generate dot graphs from the capsule store and expose CLI
- move capsules between CPU and GPU
- add context concatenation hook for LLMs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549207dce083258205bcb3272d44f3