### PR TITLE
Add Jupyter magics extension

### DIFF
--- a/herg/nbext.py
+++ b/herg/nbext.py
@@ -1,0 +1,59 @@
+"""Jupyter Notebook extension for HERG magics."""
+
+from IPython.core.magic import Magics, magics_class, line_magic
+from herg.graph_caps.store import CapsuleStore
+from herg.snapshot import save_snapshot, load_snapshot
+from herg.viz import viz_dot
+from IPython.display import SVG, display
+import argparse
+
+
+@magics_class
+class HergMagics(Magics):
+    """IPython magics for HERG."""
+
+    @line_magic
+    def herg_viz(self, line: str = ""):
+        parser = argparse.ArgumentParser(prog="%herg_viz", add_help=False)
+        parser.add_argument("last_n", nargs="?", type=int, default=500)
+        try:
+            args = parser.parse_args(line.split())
+        except SystemExit:
+            return "Usage: %herg_viz [last_n]"
+        store = CapsuleStore()
+        dot = viz_dot(store, last_n=args.last_n)
+        try:
+            display(SVG(data=dot))
+        except Exception:
+            pass
+        return dot
+
+    @line_magic
+    def herg_snapshot(self, line: str = ""):
+        parser = argparse.ArgumentParser(prog="%herg_snapshot", add_help=False)
+        sub = parser.add_subparsers(dest="cmd")
+        p_save = sub.add_parser("save")
+        p_save.add_argument("path")
+        p_load = sub.add_parser("load")
+        p_load.add_argument("path")
+        try:
+            args = parser.parse_args(line.split())
+        except SystemExit:
+            return "Usage: %herg_snapshot <save|load> <path>"
+
+        if args.cmd == "save":
+            store = CapsuleStore()
+            save_snapshot(store, args.path)
+            return f"Saved {len(store.caps)} capsules"
+        elif args.cmd == "load":
+            store = load_snapshot(args.path)
+            msg = f"Loaded {len(store.caps)} capsules"
+            print(msg)
+            return msg
+        else:
+            return "Usage: %herg_snapshot <save|load> <path>"
+
+
+def load_ipython_extension(ip):
+    """Register HERG magics."""
+    ip.register_magics(HergMagics)

--- a/tests/test_nbext.py
+++ b/tests/test_nbext.py
@@ -1,0 +1,26 @@
+import sys
+import pytest
+from IPython import get_ipython
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from herg.nbext import load_ipython_extension
+
+
+def get_shell():
+    ip = get_ipython()
+    if ip is None:
+        ip = TerminalInteractiveShell.instance()
+    return ip
+
+
+def test_herg_magics(tmp_path):
+    ip = get_shell()
+    load_ipython_extension(ip)
+
+    dot = ip.run_line_magic("herg_viz", "2")
+    assert isinstance(dot, str) and "digraph" in dot
+
+    tmp = tmp_path / "b.pkl"
+    out = ip.run_line_magic("herg_snapshot", f"save {tmp}")
+    assert tmp.exists()
+    out2 = ip.run_line_magic("herg_snapshot", f"load {tmp}")
+    assert "Loaded" in out2


### PR DESCRIPTION
## Summary
- implement nbext module with %herg_viz and %herg_snapshot magics
- display capsule graph via viz_dot and save/load snapshots
- add tests covering magics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549a25488c8325ba94e788ffffab37