### PR TITLE
Add hvlogfs storage system

### DIFF
--- a/META_LOG.md
+++ b/META_LOG.md
@@ -1,0 +1,1 @@
+* 2025-06-20 User – add hvlogfs storage scaffold and tests

--- a/docs/dev/backends.md
+++ b/docs/dev/backends.md
@@ -1,0 +1,12 @@
+# hvlogfs backends
+
+`DAXBackend` and `SPDKBackend` expose the same mmap‑style API.  The former uses
+ordinary file descriptors while the latter would talk to SPDK in production.
+For the unit tests both simply wrap Python's `mmap` module so switching is
+trivial:
+
+```python
+from herg.storage.hvlogfs import DAXBackend, SPDKBackend
+```
+
+Choose a backend at open time depending on your environment.

--- a/docs/hvlogfs.md
+++ b/docs/hvlogfs.md
@@ -1,0 +1,14 @@
+# hvlogfs
+
+`hvlogfs` provides a simple log-structured store for hypervectors. Data is
+written in 4 MiB *hyperchunks* where each vector occupies 1024 bytes plus a CRC32
+trailer. Every group of three chunks is protected with an XOR parity file.  The
+implementation used for tests is intentionally small but mirrors the production
+layout.
+
+Chunks are memory-mapped for O(1) random access.  The `MetaIndex` maps a
+32‑byte seed hash to a `(chunk_path, offset)` pair.  On retrieval the CRC is
+verified before returning the bytes as a NumPy array.
+
+A tiny write‑ahead journal provides crash safety and is replayed by higher
+levels in real deployments.

--- a/herg/api/server.py
+++ b/herg/api/server.py
@@ -1,0 +1,20 @@
+"""Minimal gRPC server stubs for hvlogfs."""
+
+import argparse
+import time
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args(argv)
+    if args.dry_run:
+        print('gRPC server starting (dry-run)...')
+        return
+    # Actual server not implemented for tests
+    while True:
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/herg/graph_caps/loader.py
+++ b/herg/graph_caps/loader.py
@@ -1,0 +1,13 @@
+from typing import Iterator, Tuple
+import numpy as np
+from ..storage.hvlogfs import HyperChunk, ENTRY_SIZE
+
+
+class HVLogLoader:
+    def __init__(self, chunk_path: str):
+        self.chunk = HyperChunk(chunk_path)
+
+    def __iter__(self) -> Iterator[Tuple[bytes, np.ndarray]]:
+        for i in range(self.chunk.count):
+            off = 64 + i * ENTRY_SIZE
+            yield b'', np.frombuffer(self.chunk.read(off), dtype=np.int8)

--- a/herg/storage/hvlogfs/__init__.py
+++ b/herg/storage/hvlogfs/__init__.py
@@ -1,0 +1,12 @@
+from .chunk import HyperChunk, ChecksumError, VECTOR_SIZE, ENTRY_SIZE, CHUNK_SIZE
+from .index import MetaIndex
+from .journal import WriteAheadJournal
+from .backend import DAXBackend, SPDKBackend
+from .graph import DiskHNSW
+from .scrub import scrub
+
+__all__ = [
+    'HyperChunk', 'ChecksumError', 'MetaIndex', 'WriteAheadJournal',
+    'DAXBackend', 'SPDKBackend', 'DiskHNSW', 'scrub',
+    'VECTOR_SIZE', 'ENTRY_SIZE', 'CHUNK_SIZE'
+]

--- a/herg/storage/hvlogfs/backend.py
+++ b/herg/storage/hvlogfs/backend.py
@@ -1,0 +1,22 @@
+import mmap
+import os
+
+
+class BackendBase:
+    def __init__(self, path: str):
+        self.path = path
+        self.fd = os.open(path, os.O_RDWR | os.O_CREAT)
+
+    def mmap(self, length: int) -> mmap.mmap:
+        return mmap.mmap(self.fd, length)
+
+    def close(self):
+        os.close(self.fd)
+
+
+class DAXBackend(BackendBase):
+    pass
+
+
+class SPDKBackend(BackendBase):
+    pass

--- a/herg/storage/hvlogfs/chunk.py
+++ b/herg/storage/hvlogfs/chunk.py
@@ -1,0 +1,80 @@
+import os
+import mmap
+import struct
+import zlib
+from typing import List
+
+VECTOR_SIZE = 1024  # bytes per vector (8192 bits)
+ENTRY_SIZE = VECTOR_SIZE + 4  # extra CRC32 per vector
+CHUNK_SIZE = 4 * 1024 * 1024  # 4 MiB
+HEADER_FMT = '<8sIII44s'  # 64 bytes total
+MAGIC = b'HVLGCHNK'
+
+
+class ChecksumError(Exception):
+    pass
+
+
+class HyperChunk:
+    """Simple hypervector chunk reader/writer with CRC checks."""
+
+    def __init__(self, path: str, mode: str = 'r+b') -> None:
+        self.path = path
+        exists = os.path.exists(path)
+        self.fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        if not exists:
+            os.ftruncate(self.fd, CHUNK_SIZE)
+        self.mm = mmap.mmap(self.fd, CHUNK_SIZE)
+        if not exists:
+            header = struct.pack(HEADER_FMT, MAGIC, 0, VECTOR_SIZE, 0, b'')
+            self.mm[:64] = header
+        else:
+            magic, self.count, vsize, crc, _ = struct.unpack(HEADER_FMT, self.mm[:64])
+            if magic != MAGIC:
+                raise ValueError('Bad chunk magic')
+            if vsize != VECTOR_SIZE:
+                raise ValueError('Vector size mismatch')
+            if crc and zlib.crc32(self.mm[64:64 + self.count * ENTRY_SIZE]) != crc:
+                raise ChecksumError('Chunk CRC mismatch')
+        if not exists:
+            self.count = 0
+
+    # ------------------------------------------------------------
+    def append(self, vectors: List[bytes]) -> List[int]:
+        """Append vectors, returning offsets."""
+        offsets = []
+        for vec in vectors:
+            if len(vec) != VECTOR_SIZE:
+                raise ValueError('Vector must be 1024 bytes')
+            if 64 + (self.count + 1) * ENTRY_SIZE > CHUNK_SIZE:
+                raise IOError('chunk full')
+            off = 64 + self.count * ENTRY_SIZE
+            crc = zlib.crc32(vec)
+            self.mm[off:off + VECTOR_SIZE] = vec
+            self.mm[off + VECTOR_SIZE: off + ENTRY_SIZE] = struct.pack('<I', crc)
+            offsets.append(off)
+            self.count += 1
+        self._write_header()
+        return offsets
+
+    # ------------------------------------------------------------
+    def read(self, offset: int) -> bytes:
+        vec = self.mm[offset:offset + ENTRY_SIZE]
+        data = vec[:VECTOR_SIZE]
+        crc_stored = struct.unpack('<I', vec[VECTOR_SIZE:ENTRY_SIZE])[0]
+        if zlib.crc32(data) != crc_stored:
+            raise ChecksumError('vector crc mismatch')
+        return data
+
+    # ------------------------------------------------------------
+    def _write_header(self) -> None:
+        chunk_crc = zlib.crc32(self.mm[64:64 + self.count * ENTRY_SIZE])
+        header = struct.pack(HEADER_FMT, MAGIC, self.count, VECTOR_SIZE, chunk_crc, b'')
+        self.mm[:64] = header
+        self.mm.flush()
+
+    def close(self) -> None:
+        self._write_header()
+        self.mm.close()
+        os.close(self.fd)
+

--- a/herg/storage/hvlogfs/fuse_mount.py
+++ b/herg/storage/hvlogfs/fuse_mount.py
@@ -1,0 +1,12 @@
+"""FUSE mount stub for hvlogfs (non-functional on tests)."""
+
+try:
+    import fuse
+except Exception:  # pragma: no cover - optional
+    fuse = None
+
+
+def mount(*args, **kwds) -> None:
+    if fuse is None:
+        raise RuntimeError('fuse not available')
+    raise NotImplementedError('FUSE mount not implemented')

--- a/herg/storage/hvlogfs/graph.py
+++ b/herg/storage/hvlogfs/graph.py
@@ -1,0 +1,43 @@
+import os
+import pickle
+from typing import List
+
+import numpy as np
+
+try:
+    import hnswlib
+    _HAVE_HNSW = True
+except Exception:  # pragma: no cover - optional
+    _HAVE_HNSW = False
+
+
+class DiskHNSW:
+    def __init__(self, dim: int, path: str):
+        self.dim = dim
+        self.path = path
+        if _HAVE_HNSW:
+            self.index = hnswlib.Index(space='cosine', dim=dim)
+            self.index.init_index(max_elements=10000, ef_construction=100, M=16)
+        else:
+            self.index: List[tuple[int, np.ndarray]] = []
+
+    def add(self, vec: np.ndarray, label: int) -> None:
+        if _HAVE_HNSW:
+            self.index.add_items(vec.reshape(1, -1), [label])
+        else:
+            self.index.append((label, vec.astype(np.float32)))
+        self._dump()
+
+    def query(self, vec: np.ndarray, k: int) -> List[int]:
+        if _HAVE_HNSW:
+            ids, _ = self.index.knn_query(vec.reshape(1, -1), k=k)
+            return ids[0].tolist()
+        dists = [float(np.dot(vec, v) / (np.linalg.norm(vec) * np.linalg.norm(v) + 1e-9))
+                 for _, v in self.index]
+        order = np.argsort(dists)[::-1][:k]
+        return [self.index[i][0] for i in order]
+
+    def _dump(self) -> None:
+        with open(self.path, 'wb') as f:
+            pickle.dump(self.index, f)
+

--- a/herg/storage/hvlogfs/index.py
+++ b/herg/storage/hvlogfs/index.py
@@ -1,0 +1,23 @@
+import os
+import pickle
+from typing import Tuple, Optional
+
+
+class MetaIndex:
+    """Very small meta index mapping seed hash to (chunk_path, offset)."""
+
+    def __init__(self, path: str):
+        self.path = path
+        try:
+            with open(self.path, 'rb') as f:
+                self._index = pickle.load(f)
+        except Exception:
+            self._index = {}
+
+    def put(self, seed_hash: bytes, location: Tuple[str, int]) -> None:
+        self._index[seed_hash] = location
+        with open(self.path, 'wb') as f:
+            pickle.dump(self._index, f)
+
+    def get(self, seed_hash: bytes) -> Optional[Tuple[str, int]]:
+        return self._index.get(seed_hash)

--- a/herg/storage/hvlogfs/journal.py
+++ b/herg/storage/hvlogfs/journal.py
@@ -1,0 +1,17 @@
+import os
+
+
+class WriteAheadJournal:
+    """Append-only journal for durability."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.f = open(path, 'ab')
+
+    def append(self, data: bytes) -> None:
+        self.f.write(data + b"\n")
+        self.f.flush()
+        os.fsync(self.f.fileno())
+
+    def close(self) -> None:
+        self.f.close()

--- a/herg/storage/hvlogfs/parity.py
+++ b/herg/storage/hvlogfs/parity.py
@@ -1,0 +1,13 @@
+from typing import Iterable
+
+
+def xor_chunks(*chunks: Iterable[bytes]) -> bytes:
+    """Return XOR parity of given byte-like chunks."""
+    if not chunks:
+        return b""
+    it = iter(chunks)
+    parity = bytearray(next(it))
+    for c in it:
+        for i, b in enumerate(c):
+            parity[i] ^= b
+    return bytes(parity)

--- a/herg/storage/hvlogfs/scrub.py
+++ b/herg/storage/hvlogfs/scrub.py
@@ -1,0 +1,42 @@
+import os
+from .chunk import HyperChunk, ENTRY_SIZE, ChecksumError
+from .parity import xor_chunks
+
+
+def scrub(path: str) -> None:
+    """Verify CRCs in all chunks at path and attempt repair using parity."""
+    chunks = [f for f in os.listdir(path) if f.endswith('.chk')]
+    chunks.sort()
+    data_chunks = [os.path.join(path, c) for c in chunks if not c.endswith('p.chk')]
+    parity_chunks = [os.path.join(path, c) for c in chunks if c.endswith('p.chk')]
+    if not parity_chunks:
+        return
+    for d0, d1, d2, p in zip(data_chunks[0::3], data_chunks[1::3], data_chunks[2::3], parity_chunks):
+        for fname in [d0, d1, d2]:
+            chunk = HyperChunk(fname)
+            for i in range(chunk.count):
+                off = 64 + i * ENTRY_SIZE
+                try:
+                    chunk.read(off)
+                except ChecksumError:
+                    rebuild(fname, d0, d1, d2, p)
+                    break
+            chunk.close()
+
+
+def rebuild(target: str, c0: str, c1: str, c2: str, parity: str) -> None:
+    """Rebuild missing chunk using XOR parity."""
+    with open(parity, 'rb') as f:
+        pbytes = f.read()
+    with open(c0, 'rb') as f:
+        b0 = f.read()
+    b1 = b''
+    if os.path.exists(c1):
+        with open(c1, 'rb') as f:
+            b1 = f.read()
+    with open(c2, 'rb') as f:
+        b2 = f.read()
+    missing = xor_chunks(pbytes, b0, b1, b2)
+    with open(target, 'wb') as f:
+        f.write(missing)
+

--- a/tests/test_hvlogfs_chunk.py
+++ b/tests/test_hvlogfs_chunk.py
@@ -1,0 +1,12 @@
+import numpy as np
+from herg.storage.hvlogfs import HyperChunk, ENTRY_SIZE
+
+
+def test_roundtrip(tmp_path):
+    path = tmp_path / 'c0.chk'
+    chunk = HyperChunk(str(path))
+    vec = bytes([1]) * 1024
+    offs = chunk.append([vec])
+    read = chunk.read(offs[0])
+    assert read == vec
+    chunk.close()

--- a/tests/test_hvlogfs_hnsw.py
+++ b/tests/test_hvlogfs_hnsw.py
@@ -1,0 +1,20 @@
+import numpy as np
+from herg.storage.hvlogfs.graph import DiskHNSW
+
+
+def test_topk_equiv(tmp_path):
+    dim = 16
+    idx = DiskHNSW(dim, str(tmp_path / 'g.idx'))
+    rng = np.random.default_rng(0)
+    vecs = rng.standard_normal((10, dim)).astype(np.float32)
+    for i, v in enumerate(vecs):
+        idx.add(v, i)
+
+    query = vecs[0]
+    res = idx.query(query, k=3)
+
+    # brute force
+    sims = vecs @ query / (np.linalg.norm(vecs, axis=1) * np.linalg.norm(query) + 1e-9)
+    brute = np.argsort(sims)[::-1][:3].tolist()
+    assert res == brute
+

--- a/tests/test_hvlogfs_meta.py
+++ b/tests/test_hvlogfs_meta.py
@@ -1,0 +1,21 @@
+import time
+import numpy as np
+from herg.storage.hvlogfs import HyperChunk, MetaIndex
+
+
+def test_lookup_latency(tmp_path):
+    chunk = HyperChunk(str(tmp_path / 'c.chk'))
+    idx = MetaIndex(str(tmp_path / 'meta.idx'))
+    vec = b'B' * 1024
+    [off] = chunk.append([vec])
+    idx.put(b'seed', (str(tmp_path / 'c.chk'), off))
+
+    t0 = time.perf_counter()
+    loc = idx.get(b'seed')
+    chunk2 = HyperChunk(loc[0])
+    out = chunk2.read(loc[1])
+    dt = time.perf_counter() - t0
+    assert dt < 0.002
+    assert out == vec
+    chunk.close(); chunk2.close()
+

--- a/tests/test_hvlogfs_parity.py
+++ b/tests/test_hvlogfs_parity.py
@@ -1,0 +1,35 @@
+import os
+import numpy as np
+from herg.storage.hvlogfs import HyperChunk
+from herg.storage.hvlogfs.parity import xor_chunks
+from herg.storage.hvlogfs.scrub import rebuild
+
+
+def test_rebuild(tmp_path):
+    d0 = HyperChunk(str(tmp_path / 'd0.chk'))
+    d1 = HyperChunk(str(tmp_path / 'd1.chk'))
+    d2 = HyperChunk(str(tmp_path / 'd2.chk'))
+
+    vec = b'A' * 1024
+    d0.append([vec])
+    d1.append([vec])
+    d2.append([vec])
+    d0.close(); d1.close(); d2.close()
+
+    with open(tmp_path / 'd0.chk', 'rb') as f:
+        b0 = f.read()
+    with open(tmp_path / 'd1.chk', 'rb') as f:
+        b1 = f.read()
+    with open(tmp_path / 'd2.chk', 'rb') as f:
+        b2 = f.read()
+    parity = xor_chunks(b0, b1, b2)
+    with open(tmp_path / 'p.chk', 'wb') as f:
+        f.write(parity)
+
+    os.remove(tmp_path / 'd1.chk')
+    rebuild(str(tmp_path / 'd1.chk'), str(tmp_path / 'd0.chk'), str(tmp_path / 'd1.chk'), str(tmp_path / 'd2.chk'), str(tmp_path / 'p.chk'))
+    rebuilt = HyperChunk(str(tmp_path / 'd1.chk'))
+    got = rebuilt.read(64)
+    assert got == vec
+    rebuilt.close()
+


### PR DESCRIPTION
## Summary
- implement hvlogfs hyperchunk storage with CRC protection
- add lightweight parity tools and disk-backed HNSW
- provide MetaIndex and journal
- expose loader and simple gRPC stub
- document hvlogfs usage and backends
- test hvlogfs roundtrip, parity rebuild, latency and HNSW search

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q`
- `python -m herg.api.server --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6854c489116c832584cd49d80408e400