### PR TITLE
Add block-binding message pass and CLI config

### DIFF
--- a/META_LOG.md
+++ b/META_LOG.md
@@ -1,1 +1,2 @@
 * 2025-06-20 User – add hvlogfs storage scaffold and tests
+* 2025-06-21 User – integrate micro-vector blocks, CLI config, bench script

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,18 @@
+# HERG CLI
+
+Basic usage:
+
+```bash
+herg run-sim --radius 3 --gossip-every 4
+herg bench ingest --n 100000
+```
+
+Flags:
+- `--radius`          k-hop message radius
+- `--alpha-u`         update rate
+- `--alpha-b`         bundling rate
+- `--eta`             learning rate
+- `--block-size`      micro-vector block size
+- `--backend`         hvlogfs backend (dax/spdk/stub)
+- `--scrub-interval`  scrubber interval seconds
+- `--gossip-every`    gossip tick interval

--- a/docs/hvlogfs.md
+++ b/docs/hvlogfs.md
@@ -12,3 +12,20 @@ verified before returning the bytes as a NumPy array.
 
 A tiny write‑ahead journal provides crash safety and is replayed by higher
 levels in real deployments.
+
+## Usage
+
+```python
+from herg.storage.hvlogfs import HyperChunk
+chunk = HyperChunk('vec.chk')
+offsets = chunk.append([b'\0'*1024]*10)
+vec = chunk.read(offsets[0])
+```
+
+Chunk layout (4 MiB example):
+
+```
++-------64B------+---------------------- data -----------------------+
+| header        | vector0 | crc | vector1 | crc | ...               |
++---------------+----------------------------------------------- ...+
+```

--- a/herg/cli.py
+++ b/herg/cli.py
@@ -1,32 +1,79 @@
-# ◇ CODEX_IMPLEMENT: snapshot CLI
 import argparse
 import sys
+from pathlib import Path
 
 from herg.snapshot import save_snapshot, load_snapshot
 from herg.graph_caps.store import CapsuleStore
+from . import config
+from .prof import Prof
 
 
-def main():
-    parser = argparse.ArgumentParser("herg snapshot")
-    subs = parser.add_subparsers(dest="cmd")
-    p_save = subs.add_parser("save")
-    p_save.add_argument("path")
-    p_load = subs.add_parser("load")
-    p_load.add_argument("path")
+def main() -> None:
+    cfg = config.load()
+    parser = argparse.ArgumentParser(prog='herg')
+    sub = parser.add_subparsers(dest='cmd')
+
+    p_run = sub.add_parser('run-sim')
+    p_run.add_argument('--radius', type=int, default=cfg.radius)
+    p_run.add_argument('--alpha-u', type=float, default=cfg.alpha_u)
+    p_run.add_argument('--alpha-b', type=float, default=cfg.alpha_b)
+    p_run.add_argument('--eta', type=float, default=cfg.eta)
+    p_run.add_argument('--block-size', type=int, default=cfg.block_size)
+    p_run.add_argument('--backend', default=cfg.backend)
+    p_run.add_argument('--scrub-interval', type=int, default=cfg.scrub_interval)
+    p_run.add_argument('--gossip-every', type=int, default=cfg.gossip_every)
+    p_run.add_argument('--profile', action='store_true')
+
+    p_bench = sub.add_parser('bench')
+    bench_sub = p_bench.add_subparsers(dest='benchcmd')
+    p_ing = bench_sub.add_parser('ingest')
+    p_ing.add_argument('--n', type=int, default=100000)
+
+    p_hv = sub.add_parser('hvlog')
+    hv_sub = p_hv.add_subparsers(dest='hvcmd')
+    p_mount = hv_sub.add_parser('mount')
+    p_mount.add_argument('path')
+
+    p_save = sub.add_parser('save')
+    p_save.add_argument('path')
+    p_load = sub.add_parser('load')
+    p_load.add_argument('path')
+
     args = parser.parse_args()
-    if args.cmd == "save":
+
+    if args.cmd == 'run-sim':
+        cfg.radius = args.radius
+        cfg.alpha_u = args.alpha_u
+        cfg.alpha_b = args.alpha_b
+        cfg.eta = args.eta
+        cfg.block_size = args.block_size
+        cfg.backend = args.backend
+        cfg.scrub_interval = args.scrub_interval
+        cfg.gossip_every = args.gossip_every
+        config.save(cfg)
+        ctx = Prof() if args.profile else nullcontext()
+        with ctx:
+            print('Simulation config updated')
+    elif args.cmd == 'bench' and args.benchcmd == 'ingest':
+        from scripts.bench_ingest import run_bench
+        run_bench(args.n)
+    elif args.cmd == 'hvlog' and args.hvcmd == 'mount':
+        from herg.storage.hvlogfs.fuse_mount import mount
+        mount(args.path)
+    elif args.cmd == 'save':
         try:
             store = load_snapshot(args.path)
         except Exception:
             store = CapsuleStore()
         save_snapshot(store, args.path)
         print(f"Saved {len(store.caps)} capsules")
-    elif args.cmd == "load":
+    elif args.cmd == 'load':
         store = load_snapshot(args.path)
         print(f"Loaded {len(store.caps)} capsules")
     else:
         parser.print_help()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
+    from contextlib import nullcontext
     main()

--- a/herg/config.py
+++ b/herg/config.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path.home() / '.config' / 'herg' / 'config.yml'
+
+@dataclass
+class Config:
+    radius: int = 2
+    alpha_u: float = 0.1
+    alpha_b: float = 0.1
+    eta: float = 0.05
+    block_size: int = 512
+    backend: str = 'stub'
+    scrub_interval: int = 60
+    gossip_every: int = 8
+
+
+def load(path: Path | None = None) -> 'Config':
+    p = Path(path or CONFIG_PATH).expanduser()
+    if p.exists():
+        data = yaml.safe_load(p.read_text()) or {}
+        return Config(**{**asdict(Config()), **data})
+    cfg = Config()
+    save(cfg, p)
+    return cfg
+
+
+def save(cfg: 'Config', path: Path | None = None) -> None:
+    p = Path(path or CONFIG_PATH).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.dump(asdict(cfg)))

--- a/herg/graph_caps/step.py
+++ b/herg/graph_caps/step.py
@@ -2,6 +2,7 @@ from collections import deque
 import numpy as np
 from herg import backend as B
 from .capsule import Capsule
+from .blocks import bind_block, BLOCK_SIZE
 
 
 def adf_update(capsule: Capsule, incoming_fast, sign: float, eta: float) -> None:
@@ -43,7 +44,10 @@ def k_radius_pass(store, radius: int) -> None:
                 if ncap is None:
                     continue
                 weight = 1.0 / (dist + 1)
-                agg.append(ncap.fast)
+                Bc = B.as_numpy(cap.fast).shape[0] // BLOCK_SIZE
+                block = (dist + 1) % Bc
+                bound = bind_block(block, ncap.fast)
+                agg.append(bound)
                 wts.append(weight)
         if agg:
             stack = B.stack(agg, axis=0)

--- a/herg/prof.py
+++ b/herg/prof.py
@@ -1,0 +1,28 @@
+import time
+from contextlib import ContextDecorator
+from herg import backend as B
+
+
+class Prof(ContextDecorator):
+    def __enter__(self):
+        self.start = time.perf_counter()
+        self.cuda_evt_start = None
+        self.cuda_evt_end = None
+        if getattr(B, '_TORCH', False):
+            import torch
+            self.cuda_evt_start = torch.cuda.Event(enable_timing=True)
+            self.cuda_evt_end = torch.cuda.Event(enable_timing=True)
+            self.cuda_evt_start.record()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        end = time.perf_counter()
+        wall = end - self.start
+        if self.cuda_evt_start is not None:
+            import torch
+            self.cuda_evt_end.record()
+            torch.cuda.synchronize()
+            cuda_ms = self.cuda_evt_start.elapsed_time(self.cuda_evt_end)
+            print(f"wall={wall:.3f}s cuda={cuda_ms/1000:.3f}s")
+        else:
+            print(f"wall={wall:.3f}s")

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "880f5db2",
+   "metadata": {},
+   "source": [
+    "## HERG Quickstart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4125b4f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from herg.graph_caps.loader import HVLogLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0d327ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.manifold import TSNE\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d37fee7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = HVLogLoader('example.chk')\n",
+    "vecs=[]\n",
+    "for i,(s,v) in zip(range(100_000), loader):\n",
+    "    vecs.append(v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5a225e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsne = TSNE(n_components=2, init='random')\n",
+    "X = tsne.fit_transform(np.vstack(vecs[:2000]).astype(np.float32))\n",
+    "plt.scatter(X[:,0], X[:,1], s=2)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/bench_ingest.py
+++ b/scripts/bench_ingest.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+import time
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from herg.storage.hvlogfs import HyperChunk
+
+
+def run_bench(n: int) -> None:
+    path = 'bench.chk'
+    if os.path.exists(path):
+        os.remove(path)
+    chunk = HyperChunk(path)
+    vec = bytes([0]) * 1024
+    from herg.storage.hvlogfs import ENTRY_SIZE, CHUNK_SIZE
+    capacity = (CHUNK_SIZE - 64) // ENTRY_SIZE
+    batch = [vec] * capacity
+    start = time.time()
+    i = 0
+    while i < n:
+        step = min(capacity, n - i)
+        try:
+            chunk.append(batch[:step])
+        except OSError:
+            idx = i // capacity
+            chunk.close()
+            chunk = HyperChunk(f'bench{idx}.chk')
+            chunk.append(batch[:step])
+        i += step
+    elapsed = time.time() - start
+    mbps = (n * 1024) / (1024 * 1024) / elapsed
+    vps = n / elapsed
+    print(f"{mbps:.1f} MB/s {vps:.0f} vectors/s")
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser()
+    p.add_argument('--n', type=int, default=1000000)
+    args = p.parse_args()
+    run_bench(args.n)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,22 @@
+from herg.graph_caps.store import CapsuleStore
+from herg.graph_caps.step import k_radius_pass
+from herg.graph_caps.blocks import bind_block, BLOCK_SIZE
+from herg import backend as B
+import numpy as np
+
+
+def test_edge_blocks_isolation():
+    store = CapsuleStore(dim=BLOCK_SIZE * 4)
+    root = store.spawn(b'r')
+    n1 = store.spawn(b'a')
+    n2 = store.spawn(b'b')
+    store.edges.add_edge(root.id, n1.id, 1)
+    store.edges.add_edge(n1.id, n2.id, 1)
+    expected = (
+        B.as_numpy(bind_block(1, n1.fast)).astype(float) * 1.0
+        + B.as_numpy(bind_block(2, n2.fast)).astype(float) * 0.5
+    )
+    expected = np.sign(expected).astype(np.int8)
+    k_radius_pass(store, radius=2)
+    cap = store.caps[root.id]
+    assert np.array_equal(B.as_numpy(cap.fast), expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+import yaml
+from pathlib import Path
+
+
+def test_cli_roundtrip(tmp_path, monkeypatch):
+    home = tmp_path
+    monkeypatch.setenv('HOME', str(home))
+    cfg_path = home / '.config' / 'herg' / 'config.yml'
+    subprocess.run([sys.executable, '-m', 'herg.cli', 'run-sim', '--radius', '3'], check=True)
+    data = yaml.safe_load(cfg_path.read_text())
+    assert data['radius'] == 3

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,25 @@
+import numpy as np
+from herg.graph_caps.store import CapsuleStore
+from herg.encoder import seed_to_hyper
+from herg import backend as B
+
+
+def test_bitflip():
+    rng = np.random.default_rng(1)
+    store = CapsuleStore(dim=240)
+    seeds = [rng.integers(0,256,32,dtype=np.uint8).tobytes() for _ in range(8)]
+    ids = []
+    for s in seeds:
+        cap = store.spawn(s)
+        ids.append(cap.id)
+    hits = 0
+    for s, cid in zip(seeds, ids):
+        hv = seed_to_hyper(s, dim=240)
+        arr = B.as_numpy(hv).copy()
+        mask = rng.random(arr.shape) < 0.2
+        arr[mask] *= -1
+        query = B.tensor(arr, dtype=np.int8)
+        best = max(store.caps.values(), key=lambda c: B.cosine(query, c.fast))
+        if best.id == cid:
+            hits += 1
+    assert hits / len(seeds) >= 0.95

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,23 @@
+import numpy as np
+from herg.graph_caps.store import CapsuleStore
+from herg.graph_caps.step import adf_update
+from herg.encoder import seed_to_hyper
+from herg import backend as B
+
+
+def test_retention_50tasks():
+    rng = np.random.default_rng(0)
+    store = CapsuleStore(dim=240)
+    seeds = [rng.integers(0,256,32,dtype=np.uint8).tobytes() for _ in range(50)]
+    ids = []
+    for s in seeds:
+        cap = store.spawn(s)
+        adf_update(cap, cap.fast, 1.0, 0.1)
+        ids.append(cap.id)
+    hits = 0
+    for s, cid in zip(seeds[:10], ids[:10]):
+        query = seed_to_hyper(s, dim=240)
+        best = max(store.caps.values(), key=lambda c: B.cosine(query, c.fast))
+        if best.id == cid:
+            hits += 1
+    assert hits / 10 >= 0.70


### PR DESCRIPTION
## Summary
- enable block-binding in `k_radius_pass`
- overhaul CLI with config management
- document CLI and hvlogfs usage
- profiling helper and ingest benchmark script
- add quickstart notebook and new tests
- update META_LOG

## Testing
- `pytest -q`
- `python scripts/bench_ingest.py --n 100000`

------
https://chatgpt.com/codex/tasks/task_e_6854c6c23c3083259d880d8577979b4a