### PR TITLE
Add smoke-sim workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+name: smoke-sim
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke-sim:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install project
+        run: |
+          python -m pip install -e .[ci]
+      - name: Run smoke simulation
+        run: bash scripts/smoke_run.sh
+      - name: Upload smoke artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-logs
+          path: artifacts/

--- a/META_LOG.md
+++ b/META_LOG.md
@@ -6,3 +6,4 @@
 * 2025-06-25 feat: packaging files for editable install
 * 2025-06-26 fix: stub heavy deps for CI
 * 2025-06-27 fix: install real NumPy/PyYAML/IPython for tests
+* 2025-06-28 chore: add smoke-sim workflow

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,4 @@
+# Continuous Integration
+
+The smoke-sim job runs the engine for about 30 seconds. Check the uploaded
+`autotune.log` and `smoke_out.txt` artifacts in the workflow run.

--- a/herg/cli.py
+++ b/herg/cli.py
@@ -41,7 +41,9 @@ def main() -> None:
     p_mount.add_argument('path')
 
     p_auto = sub.add_parser('auto-run')
+    p_auto.add_argument('--nvec', type=int, default=20000)
     p_auto.add_argument('--ticks', type=int, default=1000)
+    p_auto.add_argument('--radius', type=int, default=cfg.radius)
     p_auto.add_argument('--tune-interval', type=int, default=30)
     p_auto.add_argument('--goal', default='retention', choices=['throughput','retention','latency'])
     p_auto.add_argument('--profile', action='store_true')

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+python -m herg.cli auto-run \
+       --nvec 20000 --ticks 500 \
+       --radius 2 --tune-interval 10 --goal retention --profile \
+       | tee smoke_out.txt
+mkdir -p artifacts
+cp smoke_out.txt artifacts/
+cp ~/.cache/herg/autotune.log artifacts/ || true


### PR DESCRIPTION
## Summary
- run quick auto-run cycle in GitHub Actions
- document smoke-sim artifacts
- expose `--nvec` and `--radius` options for `auto-run`
- helper script to capture smoke logs
- log entry

## Testing
- `python tools/run_precommit.py`
- `pytest -q`
- `bash scripts/smoke_run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854db0e8ac483259a9737de76262a1a