### PR TITLE
Add RL Bandit tuner

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
+        tuner: [hill, bandit]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -21,7 +22,7 @@ jobs:
         run: |
           python -m pip install -e .[ci]
       - name: Run smoke simulation
-        run: bash scripts/smoke_run.sh
+        run: TUNER=${{ matrix.tuner }} bash scripts/smoke_run.sh
       - name: Upload smoke artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/META_LOG.md
+++ b/META_LOG.md
@@ -7,3 +7,4 @@
 * 2025-06-26 fix: stub heavy deps for CI
 * 2025-06-27 fix: install real NumPy/PyYAML/IPython for tests
 * 2025-06-28 chore: add smoke-sim workflow
+* 2025-06-29 feat: add RL bandit tuner

--- a/docs/autotune.md
+++ b/docs/autotune.md
@@ -16,3 +16,9 @@ All changes are persisted back to `~/.config/herg/config.yml`.
 Parameters never exceed predefined bounds.  Failures are logged to
 `~/.cache/herg/autotune.log` as JSON lines but never crash the main loop.
 You can visualise the metrics with `scripts/plot_autotune.py autotune.log`.
+
+## Bandit tuner
+
+`BanditTuner` implements a simple \u03b5-greedy algorithm that explores
+parameter tweaks at random early on then gradually exploits the best known
+updates.  Select it with `--tuner bandit` on the CLI.

--- a/herg/auto/daemon.py
+++ b/herg/auto/daemon.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from .metrics import MetricStore
-from .tuner import HillClimbTuner
+from .tuner import HillClimbTuner, BanditTuner
 from .. import config
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,10 @@ LOG_PATH = Path.home() / ".cache" / "herg" / "autotune.log"
 
 def start(store: MetricStore, cfg: config.Config, interval: int, goal: str) -> threading.Thread:
     LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tuner = HillClimbTuner()
+    if getattr(cfg, 'tuner', 'hill') == 'bandit':
+        tuner = BanditTuner()
+    else:
+        tuner = HillClimbTuner()
 
     def loop() -> None:
         while getattr(store, "running", True):

--- a/herg/auto/tuner.py
+++ b/herg/auto/tuner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from collections import deque
+import random
 
 
 class BoundError(Exception):
@@ -81,4 +82,100 @@ class HillClimbTuner:
             new = max(cfg.block_size - self.step["block_size"], PARAM_BOUNDS["block_size"][0])
             if new != cfg.block_size:
                 updates["block_size"] = new
+        return updates
+
+
+@dataclass
+class BanditTuner(HillClimbTuner):
+    """\u03b5-greedy bandit tuner."""
+
+    epsilon_start: float = 0.3
+    epsilon_end: float = 0.05
+    decay_steps: int = 200
+    rng: random.Random | None = None
+    steps: int = 0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.rng = self.rng or random.Random()
+        self.q: dict[tuple[int, str], float] = {}
+        self.prev_state: int | None = None
+        self.prev_action: str | None = None
+        self.prev_val: float | None = None
+
+    # --------------------------------------------------------------
+    def _epsilon(self) -> float:
+        frac = min(self.decay_steps, self.steps) / self.decay_steps
+        return max(self.epsilon_end, self.epsilon_start - (self.epsilon_start - self.epsilon_end) * frac)
+
+    # --------------------------------------------------------------
+    def suggest(self, metrics: dict, goal: str, cfg) -> dict:
+        updates: dict[str, int | float] = {}
+        metric_map = {
+            "retention": "retention",
+            "throughput": "ingest_rate",
+            "latency": "latency_p95",
+        }
+        val = metrics.get(metric_map.get(goal, "retention"), 0.0)
+
+        state = int(val * 10)
+        if self.prev_action is not None and self.prev_state is not None and self.prev_val is not None:
+            reward = val - self.prev_val
+            key = (self.prev_state, self.prev_action)
+            old = self.q.get(key, 0.0)
+            self.q[key] = 0.8 * old + 0.2 * reward
+
+        actions = []
+        for p in ["radius", "eta", "alpha_u", "block_size"]:
+            step = self.step[p]
+            actions.append(f"{p}+{step}")
+            actions.append(f"{p}-{step}")
+
+        def apply(act: str) -> dict:
+            param, op = act.split("+") if "+" in act else act.split("-")
+            delta = self.step[param]
+            if "-" in act:
+                delta = -delta
+            cur = getattr(cfg, param)
+            new = cur + delta
+            lo, hi = PARAM_BOUNDS[param]
+            new = max(lo, min(hi, new))
+            if new != cur:
+                return {param: new}
+            return {}
+
+        # pick action
+        eps = self._epsilon()
+        best = None
+        if self.rng.random() < eps:
+            best = self.rng.choice(actions)
+        else:
+            qvals = {a: self.q.get((state, a), 0.0) for a in actions}
+            best = max(qvals, key=qvals.get)
+
+        updates = apply(best)
+
+        if val < 0.97 * (self.last_good_metric or val):
+            self.bad.append(val)
+        else:
+            self.bad.clear()
+            self.last_good_metric = val
+            self.last_good_cfg = asdict(cfg)
+
+        if len(self.bad) >= 3 and self.last_good_cfg:
+            self.bad.clear()
+            self.step = {k: v / 2 for k, v in self.step.items()}
+            revert = {}
+            for k in self.last_good_cfg:
+                cur = getattr(cfg, k, None)
+                good = self.last_good_cfg[k]
+                if cur != good:
+                    revert[k] = good
+            if revert:
+                updates = revert
+
+        self.prev_state = state
+        self.prev_action = best
+        self.prev_val = val
+        self.steps += 1
         return updates

--- a/herg/cli.py
+++ b/herg/cli.py
@@ -46,6 +46,7 @@ def main() -> None:
     p_auto.add_argument('--radius', type=int, default=cfg.radius)
     p_auto.add_argument('--tune-interval', type=int, default=30)
     p_auto.add_argument('--goal', default='retention', choices=['throughput','retention','latency'])
+    p_auto.add_argument('--tuner', default=cfg.tuner, choices=['hill','cma','bandit'])
     p_auto.add_argument('--profile', action='store_true')
 
     p_save = sub.add_parser('save')
@@ -109,6 +110,9 @@ def main() -> None:
         store = CapsuleStore()
         metrics = MetricStore()
         from herg.auto import daemon
+        cfg.radius = args.radius
+        cfg.tuner = args.tuner
+        config.atomic_save(cfg)
         tuner_thread = daemon.start(metrics, cfg, args.tune_interval, args.goal)
         ctx = Prof() if args.profile else nullcontext()
         with ctx:

--- a/herg/config.py
+++ b/herg/config.py
@@ -19,6 +19,7 @@ class Config:
     scrub_interval: int = 60
     gossip_every: int = 8
     energy_drain: float = 0.0
+    tuner: str = 'hill'
 
     def apply(self, delta: dict) -> None:
         for k, v in delta.items():

--- a/scripts/smoke_run.sh
+++ b/scripts/smoke_run.sh
@@ -2,7 +2,7 @@
 set -e
 python -m herg.cli auto-run \
        --nvec 20000 --ticks 500 \
-       --radius 2 --tune-interval 10 --goal retention --profile \
+       --radius 2 --tune-interval 10 --goal retention --tuner ${TUNER:-hill} --profile \
        | tee smoke_out.txt
 mkdir -p artifacts
 cp smoke_out.txt artifacts/

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -22,6 +22,7 @@ def test_integration_run(tmp_path, monkeypatch, capsys):
         '--ticks', '200',
         '--tune-interval', '1',
         '--goal', 'retention',
+        '--tuner', 'hill',
     ]
     with mock.patch.object(sys, 'argv', argv):
         from herg.cli import main

--- a/tests/test_bandit.py
+++ b/tests/test_bandit.py
@@ -1,0 +1,21 @@
+from herg.auto.tuner import BanditTuner
+from herg import config
+import random
+
+class DummyStore:
+    def __init__(self, val=0.5):
+        self.val = val
+    def snapshot(self):
+        return {'retention': self.val}
+
+
+def test_bandit_improves():
+    store = DummyStore()
+    cfg = config.Config()
+    tuner = BanditTuner(rng=random.Random(42))
+    for _ in range(10):
+        delta = tuner.suggest(store.snapshot(), 'retention', cfg)
+        if delta:
+            cfg.apply(delta)
+            store.val += 0.01
+    assert store.val - 0.5 >= 0.05


### PR DESCRIPTION
## Summary
- implement `BanditTuner` epsilon-greedy policy
- allow selecting tuner type in CLI and config
- instantiate BanditTuner when requested by daemon
- document Bandit tuner
- test Bandit tuner and update integration tests
- extend smoke-sim workflow to run hill and bandit
- log update in `META_LOG.md`

## Testing
- `pytest -q`
- `pytest tests/test_bandit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6854de1354d0832589e7c4ee1c7713dd