### PR TITLE
Add configurable sinc kernel with CLI support

### DIFF
--- a/herg/cli.py
+++ b/herg/cli.py
@@ -1,6 +1,7 @@
 import argparse, sys
 from herg.encoder_ext import encode
 from herg.memory import MemoryCapsule
+from herg import config
 
 def demo_text():
     print("== HERG text demo ==")
@@ -10,9 +11,21 @@ def demo_text():
     print(f"encoded '{seed}' → first 8 coords: {vec[:8].tolist()}")
 
 def main(argv=None):
+    cfg = config.load()
     parser = argparse.ArgumentParser()
     parser.add_argument("--demo", choices=["text"], default="text")
+    parser.add_argument("--alpha", default=None,
+                        help="comma-separated floats for kernel scale")
+    parser.add_argument("--kernel", choices=["separable", "radial"],
+                        default=None)
     args = parser.parse_args(argv)
+
+    if args.alpha is not None:
+        vals = [float(v) for v in args.alpha.split(',')] if ',' in args.alpha else float(args.alpha)
+        cfg.kernel_alpha = vals
+    if args.kernel is not None:
+        cfg.kernel_mode = args.kernel
+    config.atomic_save(cfg)
 
     if args.demo == "text":
         demo_text()

--- a/herg/config.py
+++ b/herg/config.py
@@ -21,6 +21,8 @@ class Config:
     energy_drain: float = 0.0
     tuner: str = 'bandit'
     lane_split: tuple[int, int, int] = (4096, 2048, 2048)
+    kernel_alpha: float | list[float] = 1.0
+    kernel_mode: str = 'separable'
 
     def apply(self, delta: dict) -> None:
         for k, v in delta.items():
@@ -38,6 +40,8 @@ def load(path: Path | None = None) -> 'Config':
             data = {}
         if 'lane_split' in data:
             data['lane_split'] = tuple(data['lane_split'])
+        if 'kernel_alpha' in data and isinstance(data['kernel_alpha'], list):
+            data['kernel_alpha'] = [float(v) for v in data['kernel_alpha']]
         return Config(**{**asdict(Config()), **data})
     cfg = Config()
     save(cfg, p)
@@ -49,6 +53,8 @@ def save(cfg: 'Config', path: Path | None = None) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     data = asdict(cfg)
     data['lane_split'] = list(cfg.lane_split)
+    if isinstance(cfg.kernel_alpha, tuple):
+        data['kernel_alpha'] = list(cfg.kernel_alpha)
     p.write_text(yaml.dump(data))
 
 
@@ -61,6 +67,8 @@ def atomic_save(cfg: 'Config', path: Path | None = None) -> None:
         with lock_path(p):
             data = asdict(cfg)
             data['lane_split'] = list(cfg.lane_split)
+            if isinstance(cfg.kernel_alpha, tuple):
+                data['kernel_alpha'] = list(cfg.kernel_alpha)
             tmp.write_text(yaml.dump(data))
             os.replace(tmp, p)
     except Exception as e:  # pragma: no cover - file I/O errors

--- a/herg/encoder_ext.py
+++ b/herg/encoder_ext.py
@@ -1,11 +1,26 @@
 """Minimal encoder wrapper used by CLI demos."""
-from herg.encoder import seed_to_hyper
-from typing import Tuple
+from typing import Tuple, Sequence
+
 import numpy as np
 
+from herg import config
+from herg.encoder import seed_to_hyper
+from herg.sinc_kernel import flavor_coords, sinc_kernel
 
-def encode(seed: str | bytes) -> Tuple[np.ndarray, int]:
+
+def encode(seed: str | bytes,
+           alpha: Sequence[float] | float | None = None,
+           mode: str | None = None) -> Tuple[np.ndarray, int]:
+    """Encode seed with optional sinc-kernel modulation."""
     if isinstance(seed, str):
         seed = seed.encode()
+    cfg = config.load()
+    alpha = alpha if alpha is not None else cfg.kernel_alpha
+    mode = mode or cfg.kernel_mode
     vec = seed_to_hyper(seed)
+    coords = flavor_coords(seed).astype(np.float32)
+    coords = coords / 255.0 * 2 - 1
+    k = sinc_kernel(coords, alpha, mode=mode)
+    weight = float(np.prod(np.asarray(k)))
+    vec = vec * weight
     return vec, 0

--- a/tests/test_sinc_and_adf.py
+++ b/tests/test_sinc_and_adf.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 from herg import backend as B
-from herg.sinc_kernel import weighted_sinc, modulate
+from herg.sinc_kernel import weighted_sinc, modulate, sinc_kernel
 from herg.graph_caps.store import CapsuleStore
 
 
@@ -28,4 +29,24 @@ def test_adf_update_shrinks_distance(tmp_path):
     store.update(cid, x)
     dist2 = np.linalg.norm(x - cap.mean)
     assert dist2 < dist1
+
+
+@pytest.mark.parametrize(
+    "x,alpha",
+    [
+        (np.array([[0.5, -0.5]], dtype=np.float32), [2.0, 0.5]),
+        (np.array([[1.0, 0.0]], dtype=np.float32), [1.0, 1.0]),
+    ],
+)
+def test_sinc_kernel_separable(x, alpha):
+    out = sinc_kernel(x, alpha, mode='separable')
+    expected = np.sinc(alpha[0] * x[..., 0]) * np.sinc(alpha[1] * x[..., 1])
+    expected = expected[..., None] * np.ones_like(x)
+    assert np.allclose(out, expected)
+
+
+def test_sinc_kernel_radial_symmetry():
+    pts = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    out = sinc_kernel(pts, 1.0, mode='radial')
+    assert np.allclose(out[0], out[1])
 


### PR DESCRIPTION
## Summary
- implement generalized `sinc_kernel` supporting per‑axis scaling and radial or separable modes
- expose kernel parameters in `Config`
- allow CLI to accept `--alpha` and `--kernel` flags
- apply kernel modulation during encoding
- extend sinc kernel tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856244262c88325978956c084a34801