### PR TITLE
Add radial kernel and decay update

### DIFF
--- a/herg/memory.py
+++ b/herg/memory.py
@@ -13,7 +13,13 @@ class MemoryCapsule:
     energy: float = 1.0
 
     def update(self, vec: np.ndarray, reward: float = 0.0) -> None:
-        self.mu = (1 - LR) * self.mu + LR * vec
+        """Apply ADF update with decay as in PDF eqn (5)."""
+        mu_old = self.mu.copy()
+        delta = LR * (vec - mu_old)
+        mu_lin = mu_old + delta
+        # DECAY per PDF eqn (5)
+        self.mu = DECAY * mu_old + (1 - DECAY) * mu_lin
+        # same DECAY factor for energy assimilation
         self.energy = self.energy * DECAY + 0.01 * reward
         self.meta["ts"] = time.time()
 

--- a/tests/test_memory_decay.py
+++ b/tests/test_memory_decay.py
@@ -1,0 +1,10 @@
+import numpy as np
+from herg.memory import MemoryCapsule
+
+
+def test_memory_update_no_change_when_same_vec():
+    mu = np.random.rand(4).astype(np.float32)
+    cap = MemoryCapsule(1, mu.copy(), {})
+    cap.update(mu)
+    assert np.allclose(cap.mu, mu)
+

--- a/tests/test_sinc_and_adf.py
+++ b/tests/test_sinc_and_adf.py
@@ -50,3 +50,12 @@ def test_sinc_kernel_radial_symmetry():
     out = sinc_kernel(pts, 1.0, mode='radial')
     assert np.allclose(out[0], out[1])
 
+
+def test_sinc_kernel_radial_alpha_mean():
+    x = np.array([[1.0, 0.5]], dtype=np.float32)
+    alpha = [2.0, 0.5]
+    out = sinc_kernel(x, alpha, mode='radial')
+    r = np.linalg.norm(x, axis=-1)
+    expected = np.sinc(np.mean(alpha) * r)[..., None] * np.ones_like(x)
+    assert np.allclose(out, expected)
+


### PR DESCRIPTION
## Summary
- extend `sinc_kernel` with `alpha` array and `radial` mode
- incorporate decay into `MemoryCapsule.update`
- test radial scaling and decay logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685627bbcbf883258e33ecf5e4a5bd84