### PR TITLE
Fix CLI script and optional faiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ A lightweight, self-evolving hyper-vector reasoning graph.
 git clone https://github.com/RedactedCoder23/HERG.git
 cd HERG
 pip install -e .[dev]          # editable install
-herg-run --demo text
+# try a quick text demo with a few seeds
+herg-run --demo text --seed foo --seed bar --seed baz
+# Faiss is optional; without it some demo features may raise ImportError
+# If pip install faiss-cpu fails, try `conda install -c conda-forge faiss-cpu`
+# or set `USE_FLAT=1` before running the demo.
 ```
 
 ### Code Coverage

--- a/herg-agent/agent/utils.py
+++ b/herg-agent/agent/utils.py
@@ -25,7 +25,10 @@ if __name__ == "__main__":
         sys.stdout.buffer.write(add_prefix(data))
 
 import numpy as np
-import faiss
+try:
+    import faiss
+except ModuleNotFoundError:
+    faiss = None
 from herg.faiss_wrapper import HybridIndex
 
 
@@ -36,6 +39,8 @@ def safe_search(index, xb, k: int):
     if isinstance(index, HybridIndex):
         D, I = index.search(np.asarray(xb, np.uint8), k)
         return D.astype(np.float32), I
+    if faiss is None:
+        raise ImportError("faiss library not installed")
     D, I = index.search(np.asarray(xb, np.float32), k)
     return D.astype(np.float32), I
 

--- a/herg/cli.py
+++ b/herg/cli.py
@@ -1,19 +1,76 @@
 import argparse, sys
-from herg.encoder_ext import encode
-from herg.memory import MemoryCapsule
+import numpy as np
+from pathlib import Path
+
+AGENT_PATH = Path(__file__).resolve().parents[1] / "herg-agent"
+if AGENT_PATH.exists():
+    sys.path.append(str(AGENT_PATH))
+from herg.memory import MemoryCapsule, maybe_branch
+from herg.storage.hvlogfs import HVLogFS
+from herg.faiss_wrapper import HybridIndex
+from agent.encoder_ext import expand_seed, prefix, LANE_SPLIT
+from agent.utils import safe_search, cosine
+
+class _Graph:
+    def __init__(self):
+        self.nodes = {}
+        self.edges = []
+        self._next = 1
+
+    def add(self, cap):
+        self.nodes[cap.id_int] = cap
+
+    def add_edge(self, src, dst, route=""):
+        self.edges.append((src, dst, route))
+
+    def __getitem__(self, key):
+        return self.nodes[key]
+
+    def new_id(self):
+        nid = self._next
+        self._next += 1
+        return nid
 from herg import config
 
-def demo_text():
+def demo_text(seeds):
     print("== HERG text demo ==")
-    seed = "hello"
-    vec, _ = encode(seed)
-    cap = MemoryCapsule(1, vec, {})
-    print(f"encoded '{seed}' → first 8 coords: {vec[:8].tolist()}")
+
+    hvlog = HVLogFS("/tmp/hvlog")
+    index = HybridIndex(LANE_SPLIT)
+    id_map = []
+    graph = _Graph()
+
+    if not seeds:
+        seeds = ["hello"]
+
+    for seed in seeds:
+        vec, h = expand_seed(seed)
+        D, I = safe_search(index, vec, 1)
+        if I.size:
+            cid = id_map[int(I[0][0])]
+            cap = graph[cid]
+            cos = cosine(cap.mu, vec.astype(np.float32))
+            if cos > 0.88:
+                cap.update(vec.astype(np.float32))
+                hvlog.append_cap(prefix(h), cid, cap.mu, cap.meta)
+                maybe_branch(graph, cap, vec.astype(np.float32), 0.0)
+                print(f"Queried 1 vector, best match cos={cos:.2f}")
+                continue
+
+        cid = graph.new_id()
+        cap = MemoryCapsule(cid, vec.astype(np.float32), {})
+        graph.add(cap)
+        hvlog.append_cap(prefix(h), cid, cap.mu, cap.meta)
+        index.add(vec)
+        id_map.append(cid)
+        print(f"Inserted 1 vector, total capsules: {len(graph.nodes)}")
 
 def main(argv=None):
     cfg = config.load()
     parser = argparse.ArgumentParser()
     parser.add_argument("--demo", choices=["text"], default="text")
+    parser.add_argument("--seed", action="append", default=[],
+                        help="seed string; may be repeated")
     parser.add_argument("--alpha", default=None,
                         help="comma-separated floats for kernel scale")
     parser.add_argument("--kernel", choices=["separable", "radial"],
@@ -28,7 +85,7 @@ def main(argv=None):
     config.atomic_save(cfg)
 
     if args.demo == "text":
-        demo_text()
+        demo_text(args.seed)
 
 if __name__ == "__main__":
     main()

--- a/herg/faiss_wrapper.py
+++ b/herg/faiss_wrapper.py
@@ -1,4 +1,7 @@
-import faiss
+try:
+    import faiss
+except ModuleNotFoundError:  # optional for simple demos
+    faiss = None
 import numpy as np
 import os
 from .distance import hybrid_hamming
@@ -34,8 +37,10 @@ class HybridIndex:
         return D, I
 
 
-def make_index(dim: int) -> faiss.Index:
-    """Return FAISS index; USE_FLAT=1 forces simple FlatL2."""
+def make_index(dim: int):
+    """Return FAISS index if available; else raise ImportError."""
+    if faiss is None:
+        raise ImportError("faiss library not installed")
     if os.getenv("USE_FLAT", "") == "1":
         return faiss.IndexFlatL2(dim)
     return faiss.IndexFlatL2(dim)


### PR DESCRIPTION
## Summary
- make herg-run console entry point discoverable
- implement text demo that adds/query capsules
- handle missing `faiss` gracefully for demo usage
- document Faiss install tips
- drop leftover unused import

## Testing
- `pytest -q`
- `herg-run --demo text --seed foo --seed bar --seed baz`


------
https://chatgpt.com/codex/tasks/task_e_68566c18a9e08325a8c5498a244197a8